### PR TITLE
slide 11 was empty in welcome walkthrough

### DIFF
--- a/app/welcomewizard/Slide11.qml
+++ b/app/welcomewizard/Slide11.qml
@@ -32,8 +32,8 @@ Component {
         Item {
             id: imageContainer
 
-            width: isLandscape ? slide11.width/2 : slide11.width
-            height: isLandscape ? slide11.height : slide11.height/2
+            width: isLandscape ? parent.width/2 : parent.width
+            height: isLandscape ? parent.height : parent.height/2
 
             Image {
                 width: Math.min(parent.width, parent.height)


### PR DESCRIPTION
Slide11.qml:35: TypeError: Cannot read property 'width' of null
Slide11.qml:36: TypeError: Cannot read property 'height' of null

I was able to reproduce the problem with "clickable --desktop -k 16.04" (could not test it on a device yet)
getting the width / height from parent instead of id "slide11" solved the problem for me.

Note: the following warnings are still present in the console output, but I haven't noticed a visible problem with those:
welcomewizard/SlideBase.qml:71: TypeError: Cannot read property of null
welcomewizard/SlideBase.qml:72: TypeError: Cannot read property of null
welcomewizard/SlideBase.qml:73: TypeError: Cannot read property of null
 
should fix https://github.com/ubports/ubuntu-touch/issues/737
